### PR TITLE
Fix Python syntax error caused by a missing comma

### DIFF
--- a/www.zhongchou.com/zhongchou.py
+++ b/www.zhongchou.com/zhongchou.py
@@ -110,7 +110,7 @@ def zhongchou():
         try:
             info=get_project_info(line[-1])
         except Exception as e:
-            print(line,'Error' e)
+            print(line,'Error',e)
             failed=open('failed.txt','a')
             failed.write(str(line)+'\n')
             failed.close()


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/Nyloner/Nyspider on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./Nyspider.py:57:19: F821 undefined name '_format_addr'
    msg['From'] = _format_addr(user)
                  ^
./Nyspider.py:58:17: F821 undefined name '_format_addr'
    msg['To'] = _format_addr(email)
                ^
./tianqi.2345.com/load_city.py:23:21: F821 undefined name 'json'
            f.write(json.dumps(city)+'\n')
                    ^
./www.aihuishou.com/get_price.py:116:7: F821 undefined name 'xlwt3'
    f=xlwt3.Workbook()
      ^
./www.converse.com.cn/converse.py:91:72: F821 undefined name 'url'
                print(current_time(), '[get_products][request error]', url, e)
                                                                       ^
./stock.finance.qq.com/stk_holder.py:31:17: F821 undefined name 'result'
    for line in result:
                ^
./www.autozi.com/carBrandLetter.py:12:76: F821 undefined name 'headers'
    html=requests.get('http://www.autozi.com/carBrandLetter/.html',headers=headers).text
                                                                           ^
./JobGet/JobInforGet.py:219:10: F821 undefined name 'get51Url'
    urls=get51Url()
         ^
./wzzxbs.mofcom.gov.cn/util.py:55:18: F821 undefined name 'json'
            item=json.loads(line)
                 ^
./www.mohurd.gov.cn/deal.py:20:11: F821 undefined name 'loadLevel'
    level=loadLevel()
          ^
./forecast.io/getData.py:21:107: F821 undefined name 'proxies'
    html=session.get('http://forecast.io/forecast?q=35,105,%s&satellites'%timestr,headers=headers,proxies=proxies).text
                                                                                                          ^
./www.eastmoney.com/guba.py:80:9: F821 undefined name 'os'
        os.mkdir('result')
        ^
./www.zhongchou.com/zhongchou.py:113:32: E999 SyntaxError: invalid syntax
            print(line,'Error' e)
                               ^
./dir.scmor.com/google.py:20:16: F821 undefined name 'unichr'
        return unichr(a%65536) + ''.join([unichr(i%65536) for i in b])
               ^
./dir.scmor.com/google.py:20:43: F821 undefined name 'unichr'
        return unichr(a%65536) + ''.join([unichr(i%65536) for i in b])
                                          ^
1     E999 SyntaxError: invalid syntax
14    F821 undefined name 'get51Url'
15
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree